### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -149,7 +149,7 @@ setSoftCurrentLimit	KEYWORD2
 getEEPROMSettings	KEYWORD2
 getRAMSettings	KEYWORD2
 setRAMSettings	KEYWORD2
-getVariables                            KEYWORD2
+getVariables	KEYWORD2
 
 getLastError	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords